### PR TITLE
Make unit tests run in test plan

### DIFF
--- a/BTLB.xcodeproj/xcshareddata/xcschemes/BTLBTests.xcscheme
+++ b/BTLB.xcodeproj/xcshareddata/xcschemes/BTLBTests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1520"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,6 +27,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:BTLBTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "YES">
@@ -61,16 +67,6 @@
                BuildableName = "BookmarksTests"
                BlueprintName = "BookmarksTests"
                ReferencedContainer = "container:Packages/Bookmarks">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3B263C5A1F84D3B60032159A"
-               BuildableName = "BTLBUITests.xctest"
-               BlueprintName = "BTLBUITests"
-               ReferencedContainer = "container:BTLB.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
@@ -117,26 +113,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LibraryCoreTests"
-               BuildableName = "LibraryCoreTests"
-               BlueprintName = "LibraryCoreTests"
-               ReferencedContainer = "container:Packages/LibraryCore">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LibraryUITests"
-               BuildableName = "LibraryUITests"
-               BlueprintName = "LibraryUITests"
-               ReferencedContainer = "container:Packages/LibraryUI">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "LoansTests"
                BuildableName = "LoansTests"
                BlueprintName = "LoansTests"
@@ -157,40 +133,10 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "MoreTests"
-               BuildableName = "MoreTests"
-               BlueprintName = "MoreTests"
-               ReferencedContainer = "container:Packages/More">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NetworkingTests"
-               BuildableName = "NetworkingTests"
-               BlueprintName = "NetworkingTests"
-               ReferencedContainer = "container:Packages/Networking">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "PersistenceTests"
                BuildableName = "PersistenceTests"
                BlueprintName = "PersistenceTests"
                ReferencedContainer = "container:Packages/Persistence">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SearchTests"
-               BuildableName = "SearchTests"
-               BlueprintName = "SearchTests"
-               ReferencedContainer = "container:Packages/Search">
             </BuildableReference>
          </TestableReference>
          <TestableReference

--- a/BTLB.xctestplan
+++ b/BTLB.xctestplan
@@ -14,9 +14,86 @@
   "testTargets" : [
     {
       "target" : {
+        "containerPath" : "container:Packages\/More",
+        "identifier" : "MoreTests",
+        "name" : "MoreTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:BTLB.xcodeproj",
+        "identifier" : "3BB68AB91FFFA3DF00A1F616",
+        "name" : "BTLBTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Networking",
+        "identifier" : "NetworkingTests",
+        "name" : "NetworkingTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Charges",
+        "identifier" : "ChargesTests",
+        "name" : "ChargesTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Libraries",
+        "identifier" : "LibrariesTests",
+        "name" : "LibrariesTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Loans",
+        "identifier" : "LoansTests",
+        "name" : "LoansTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Persistence",
+        "identifier" : "PersistenceTests",
+        "name" : "PersistenceTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/BTLBIntents",
+        "identifier" : "BTLBIntentsTests",
+        "name" : "BTLBIntentsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Localization",
+        "identifier" : "LocalizationTests",
+        "name" : "LocalizationTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:Packages\/Accounts",
         "identifier" : "AccountsTests",
         "name" : "AccountsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Bookmarks",
+        "identifier" : "BookmarksTests",
+        "name" : "BookmarksTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/BTLBSettings",
+        "identifier" : "BTLBSettingsTests",
+        "name" : "BTLBSettingsTests"
       }
     }
   ],

--- a/BTLB.xcworkspace/contents.xcworkspacedata
+++ b/BTLB.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:BTLB.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:BTLBTests.xctestplan">
+   </FileRef>
 </Workspace>

--- a/BTLBTests.xctestplan
+++ b/BTLBTests.xctestplan
@@ -1,0 +1,98 @@
+{
+  "configurations" : [
+    {
+      "id" : "1A07C502-895E-4DC2-B101-BC4AA58BEB4C",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "enabled" : false,
+      "skippedTests" : [
+        "APITests"
+      ],
+      "target" : {
+        "containerPath" : "container:BTLB.xcodeproj",
+        "identifier" : "3BB68AB91FFFA3DF00A1F616",
+        "name" : "BTLBTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Accounts",
+        "identifier" : "AccountsTests",
+        "name" : "AccountsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Bookmarks",
+        "identifier" : "BookmarksTests",
+        "name" : "BookmarksTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/BTLBIntents",
+        "identifier" : "BTLBIntentsTests",
+        "name" : "BTLBIntentsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/BTLBSettings",
+        "identifier" : "BTLBSettingsTests",
+        "name" : "BTLBSettingsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Charges",
+        "identifier" : "ChargesTests",
+        "name" : "ChargesTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Libraries",
+        "identifier" : "LibrariesTests",
+        "name" : "LibrariesTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Loans",
+        "identifier" : "LoansTests",
+        "name" : "LoansTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Localization",
+        "identifier" : "LocalizationTests",
+        "name" : "LocalizationTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Persistence",
+        "identifier" : "PersistenceTests",
+        "name" : "PersistenceTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/Utilities",
+        "identifier" : "UtilitiesTests",
+        "name" : "UtilitiesTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Packages/Localization/Tests/LocalizationTests/LocalizationTests.swift
+++ b/Packages/Localization/Tests/LocalizationTests/LocalizationTests.swift
@@ -1,11 +1,11 @@
-import XCTest
+import Testing
+import SwiftUI
 @testable import Localization
 
-final class LocalizationTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(Localization.Accounts.emptyHint, "Pretty empty here ☝️ this will change once you have setup your library account.")
+class LocalizationTests {
+
+    @Test
+    func testLocalization() throws {
+        #expect(Localization.Accounts.emptyHint == LocalizedStringKey(stringLiteral: "no accounts hint text"))
     }
 }


### PR DESCRIPTION
These changes adds many of the unit tests to a common test plan. There are still test suites missing from this common test plan but it's a start.

Run tests by selecting the BTLB scheme and `cmd + U`.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/196541e6-8d68-4487-bfc5-fad5db18c6f6" />


Fixes #4 