### PR TITLE
Update xcode cloud ci pipeline

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
+# Allow Xcode Plugins on ci
+defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+
+# Prepare Build
 mv ../Secrets.sample.xcconfig ../Secrets.xcconfig
 
+# Install Dependencies
 brew install rust
 
 cargo install cargo-swift@^0.9.0 --force --locked
@@ -10,10 +15,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 export PATH="$HOME/.cargo/bin:$PATH"
 
+# Make the Paper Swift Package
 cd ../Packages/shared/paper
-
 make prepare-apple
-
 cd paper
-
 make apple-release


### PR DESCRIPTION
Some ci builds failed as an Xcode plugin was not trusted. Interestingly previous builds had passed 🙀

Error that should be fixed with these changes is:

> Macro “ObfuscateMacroPlugin” from package “ObfuscateMacro” must be enabled before it can be used